### PR TITLE
anchoring xmldom to 0.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "teddy",
   "description": "Teddy Templating Engine",
   "author": "Eric Newport <kethinov@gmail.com>",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "homepage": "https://github.com/kethinov/teddy",
   "license": "CC-BY-4.0",
   "main": "teddy.js",
@@ -12,7 +12,7 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "xmldom": "^0.1.19"
+    "xmldom": "0.1.19"
   },
   "jshintConfig": {
     "camelcase": true,


### PR DESCRIPTION
due to regressions caused by newer releases of xmldom