### PR TITLE
Unit test for objects that don't exist

### DIFF
--- a/test/misc.js
+++ b/test/misc.js
@@ -41,4 +41,9 @@ describe('Misc', function() {
     assert.equalIgnoreSpaces(teddy.render('misc/serverSideCommentsNested.html', model), '<p>Any comments? </p>');
     done();
   });
+
+  it.only('should not break when referencing objects that don\'t exist (misc/objectDoesNotExist.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('misc/objectDoesNotExist.html', model), '');
+    done();
+  });
 });

--- a/test/templates/misc/objectDoesNotExist.html
+++ b/test/templates/misc/objectDoesNotExist.html
@@ -1,0 +1,10 @@
+{!
+  should not break when evaluating <if something.doesntExist>
+!}
+<if doesntExist.someKey>
+  <p>This should not display</p>
+</if>
+
+<p>{doesntExist.someKey}</p>
+
+<p if-doesntExist.someKey true='class=true' false='class=false'></p>


### PR DESCRIPTION
Trying to reference an object that doesn't exist causes teddy to throw an error, in turn causing the page not to render