### PR TITLE
test including template with numeric variable in argument

### DIFF
--- a/test/includes.js
+++ b/test/includes.js
@@ -46,4 +46,9 @@ describe('Includes', function() {
     assert.equalIgnoreSpaces(teddy.render('includes/argVariableWithinArg.html', model), 'Render aborted due to max number of passes (' + teddy.params.maxPasses + ') exceeded; there is a possible infinite loop in your template logic.');
     done();
   });
+
+  it('should <include> a template that contains numerical {variables} (includes/numericVarInArg.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/numericVarInArg.html', model), '<p>STRING!</p>');
+    done();
+  });
 });

--- a/test/models/model.js
+++ b/test/models/model.js
@@ -42,7 +42,7 @@ module.exports = function() {
       hello: 'world',
       number: 10,
       nameReference: 'jack',
-      3: 'Unexpected String',
+      3: 'STRING!',
       largeDataSet: []
     },
     i,

--- a/test/templates/includes/numericVarInArg.html
+++ b/test/templates/includes/numericVarInArg.html
@@ -1,0 +1,8 @@
+{!
+  should <include> a template that contains numerical {variables}
+!}
+<include src='misc/markupArgument'>
+ <arg something>
+   <p>{3}</p>
+ </arg>
+</include>


### PR DESCRIPTION
Numeric named root-level properties don't work in general, but inside of an argument an additional `data-local-model` is exposed as well.