### PR TITLE
test including a template with numeric arguments

### DIFF
--- a/test/includes.js
+++ b/test/includes.js
@@ -56,4 +56,9 @@ describe('Includes', function() {
     assert.equalIgnoreSpaces(teddy.render('includes/conditionArgInStyle.html', model), '<style>#p { height: 20px; }</style>');
     done();
   });
+
+  it('should <include> a template with numeric arguments (includes/numericArgument.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/numericArgument.html', model), '<p>Hello!</p>');
+    done();
+  });
 });

--- a/test/templates/includes/numericArgument.html
+++ b/test/templates/includes/numericArgument.html
@@ -1,0 +1,8 @@
+{!
+  should <include> a template with numeric arguments
+!}
+<include src='misc/numericMarkupArgument'>
+  <arg 3>
+    <p>Hello!</p>
+  </arg>
+</include>

--- a/test/templates/misc/numericMarkupArgument.html
+++ b/test/templates/misc/numericMarkupArgument.html
@@ -1,0 +1,4 @@
+{!
+  should render numeric variable markup
+!}
+{3}


### PR DESCRIPTION
Results in error:

```
SyntaxError: Invalid regular expression: /{3}/: Nothing to repeat
      at RegExp (native)
      at renderVar (teddy.js:1117:26)
      at renderInclude (teddy.js:681:20)
      at parseIncludes (teddy.js:449:16)
      at parseNonLoopedElements (teddy.js:323:30)
      at Object.render (teddy.js:336:15)
      at Context.<anonymous> (test/includes.js:61:36)
```