### PR TITLE
test argument overriding model values

### DIFF
--- a/test/includes.js
+++ b/test/includes.js
@@ -75,4 +75,9 @@ describe('Includes', function() {
     assert.equalIgnoreSpaces(teddy.render('includes/inlineScriptTag.html', model), '<p>Hello!</p><script>console.log(\'Hello world\'); for (var i = 0; i < 2; i++) { console.log(\'Test\') } </script>');
     done();
   });
+
+  it('should evaluate {variable} outside of include as original model value (includes/argRedefineModelVar.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/argRedefineModelVar.html', model), '<style>p { height: 10px }</style> <p>Some content</p>');
+    done();
+  });
 });

--- a/test/templates/includes/argRedefineModelVar.html
+++ b/test/templates/includes/argRedefineModelVar.html
@@ -1,0 +1,13 @@
+{!
+  should evaluate {variable} outside of include as original model value
+!}
+<include src='misc/markupArgument'>
+  <arg something>
+    <style>
+      p {
+        height: 10px;
+      }
+    </style>
+  </arg>
+</include>
+<p>{something}</p>


### PR DESCRIPTION
The style tag is an example of a natural use case that would cause this.

When an argument with a name matching a variable in the model contains curly braces `{ }` It will permanently override the original model's variable. In this case the `{something}` evaluates as the `style` tag.