### PR TITLE
Test escaping regex pattern in argument

### DIFF
--- a/test/includes.js
+++ b/test/includes.js
@@ -73,4 +73,9 @@ describe('Includes', function() {
     assert.equalIgnoreSpaces(teddy.render('includes/argRedefineModelVar.html', model), '<style>p { height: 10px; }</style> <p>Some content</p>');
     done();
   });
+
+  it('should <include> a template and escape regex pattern in argument (includes/includeEscapeRegex.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/includeEscapeRegex.html', model), '<input type=\'text\' name=\'date\' placeholder=\'DD/MM/YYYY\' id=\'date\' pattern=\'^(3[0-1]|[1-2]\\d|[1-9]|0\\d)\\/(1[0-2]|[1-9]|0\\d)\\/[1-2]\\d{3}$\'>');
+    done();
+  });
 });

--- a/test/templates/includes/includeEscapeRegex.html
+++ b/test/templates/includes/includeEscapeRegex.html
@@ -1,0 +1,9 @@
+{!
+  should <include> a template and escape regex pattern in argument
+!}
+
+<include src='misc/markupArgument'>
+  <arg something>
+    <input type='text' name='date' placeholder='DD/MM/YYYY' id='date' pattern='^(3[0-1]|[1-2]\d|[1-9]|0\d)\/(1[0-2]|[1-9]|0\d)\/[1-2]\d{3}$'>
+  </arg>
+</include>


### PR DESCRIPTION
Evaluates as 
```
<input type='text' name='date' placeholder='DD/MM/YYYY' id='date' pattern='^(3[0-1]|[1-2]\d|[1-9]|0\d)\/(1[0-2]|[1-9]|0\d)\/[1-2]\d{3 }
>
```

:(