### PR TITLE
Remove warning from loops with bad variables (Closes #109)

### DIFF
--- a/teddy.js
+++ b/teddy.js
@@ -877,7 +877,6 @@
           var key = getAttribute(el, 'key'),
               val = getAttribute(el, 'val'),
               collection = getAttribute(el, 'through'),
-              collectionString = collection,
               loopContent,
               localModel,
               item,

--- a/teddy.js
+++ b/teddy.js
@@ -904,10 +904,6 @@
           collection = getNestedObjectByString(model, collection);
 
           if (!collection) {
-            if (teddy.params.verbosity) {
-              teddy.console.warn('loop element found with undefined value "' + collectionString + '" specified for "through" or "in" attribute. Ignoring element.');
-            }
-
             return '';
           }
           else {

--- a/test/looping.js
+++ b/test/looping.js
@@ -128,9 +128,7 @@ describe('Looping', function() {
   });
 
   it('should ignore loop with invalid through attribute (looping/undefinedObjectLoop.html)', function(done) {
-    teddy.setVerbosity(0);
     assert.equalIgnoreSpaces(teddy.render('looping/undefinedObjectLoop.html', model), '<div></div>');
-    teddy.setVerbosity(1);
     done();
   });
 


### PR DESCRIPTION
I do believe we have a relevant test to assure these loops also don't pollute the markup here:

https://github.com/kethinov/teddy/blob/master/test/looping.js#L130