### PR TITLE
add coverage analyzer to teddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ results
 npm-debug.log
 .DS_Store
 node_modules
+coverage
 
 .jshintrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "node"
+after_success:
+  - istanbul cover ./node_modules/mocha/bin/_mocha
+  - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "eslint": "3.13.1",
     "mocha": "3.2.0",
     "chai": "3.5.0",
-    "chai-string": "1.3.0"
+    "chai-string": "1.3.0",
+    "istanbul": "0.4.5",
+    "mocha-lcov-reporter": "1.3.0",
+    "coveralls": "2.12.0"
   },
   "eslintConfig": {
     "env": {
@@ -51,7 +54,8 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --recursive test",
-    "eslint": "./node_modules/.bin/eslint ."
+    "eslint": "./node_modules/.bin/eslint .",
+    "cover": "istanbul cover ./node_modules/.bin/_mocha --recursive test"
   },
   "pre-commit": [
     "test",


### PR DESCRIPTION
It's finally here!

This PR will add code coverage to our tests and build process as well as a convenient command `npm run cover` to check our code coverage locally.

Steps to getting coverage to work with travis:

1. Sign into https://coveralls.io with your github account
2. Add teddy as a repo to cover (Similar interface to enabling travis)
3. Go into Repos and into teddy to grab the markdown for the coverage badge for the readme
4. ???
5. Profit