### PR TITLE
test for various invalid include markup structures

### DIFF
--- a/teddy.js
+++ b/teddy.js
@@ -780,8 +780,6 @@
               args[i] = '<arg' + args[i] + '</arg>';
               argname = args[i].split('<arg ');
               argname = argname[1];
-              argname = argname.split('>');
-              argname = argname[0];
 
               if (!argname) {
                 if (teddy.params.verbosity) {
@@ -790,6 +788,8 @@
                 return '';
               }
 
+              argname = argname.split('>');
+              argname = argname[0];
               argval = getInnerHTML(args[i]);
 
               // replace template string argument {var} with argument value

--- a/test/client.html
+++ b/test/client.html
@@ -384,7 +384,7 @@
         'includes/inlineScriptTag.html',
         'includes/argRedefineModelVar.html',
         'includes/includeEscapeRegex.html',
-        'includes/includeInvalidTemplate.html',
+        'includes/invalidIncludeMarkup.html',
         'looping/emptyMarkupLoop.html',
         'looping/largeDataSet.html',
         'looping/loopArrayOfObjects.html',

--- a/test/includes.js
+++ b/test/includes.js
@@ -84,10 +84,8 @@ describe('Includes', function() {
     done();
   });
 
-  it('should skip rendering <include> that references a nonexistent template (includes/includeInvalidTemplate.html)', function(done) {
-    teddy.setVerbosity(0);
-    assert.equalIgnoreSpaces(teddy.render('includes/includeInvalidTemplate.html', model), '<div></div>');
-    teddy.setVerbosity(1);
+  it('should ignore includes with invalid markup and print console warnings (includes/invalidIncludeMarkup.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/invalidIncludeMarkup.html', model), '<div></div>');
     done();
   });
 });

--- a/test/templates/includes/includeInvalidTemplate.html
+++ b/test/templates/includes/includeInvalidTemplate.html
@@ -1,6 +1,0 @@
-{!
-  should skip rendering <include> that references a nonexistent template
-!}
-<div>
-  <include src='noExist.html'></include>
-</div>

--- a/test/templates/includes/invalidIncludeMarkup.html
+++ b/test/templates/includes/invalidIncludeMarkup.html
@@ -1,0 +1,16 @@
+{!
+  should ignore includes with invalid markup and print console warnings
+!}
+<div>
+  {! Missing src attribute !}
+  <include></include>
+
+  {! references nonexistent template !}
+  <include src='noExist.html'></include>
+
+  {! arg element with no attribute !}
+  <include src='misc/variable'>
+    <arg></arg>
+  </include>
+</div>
+

--- a/test/templates/looping/loopInvalidAttributes.html
+++ b/test/templates/looping/loopInvalidAttributes.html
@@ -2,10 +2,18 @@
   should ignore loops with missing attributes
 !}
 <div>
+  {! missing val attribute !}
   <loop through='letters'>
     <p>{letter}</p>
   </loop>
+
+  {! missing through attribute !}
   <loop val='letter'>
+    <p>{letter}</p>
+  </loop>
+
+  {! no attributes !}
+  <loop>
     <p>{letter}</p>
   </loop>
 </div>


### PR DESCRIPTION
While the purpose of these tests was to increase coverage it turns out there's actually a bug here.

The empty attribute arg portion of this tests throws this error causing the test to fail:

```
TypeError: Cannot read property 'split' of undefined
      at renderInclude (teddy.js:783:32)
      at parseIncludes (teddy.js:553:20)
      at parseNonLoopedElements (teddy.js:423:30)
      at Object.render (teddy.js:436:15)
      at Context.<anonymous> (test/includes.js:88:36)
```

According to the source code in the event of an arg with no attribute the parent include should be ignored and a warning printed at all > 0 verbosity levels.