### PR TITLE
resurrect undefined through/in loop warning with higher verbosity

### DIFF
--- a/teddy.js
+++ b/teddy.js
@@ -877,6 +877,7 @@
           var key = getAttribute(el, 'key'),
               val = getAttribute(el, 'val'),
               collection = getAttribute(el, 'through'),
+              collectionString = collection,
               loopContent,
               localModel,
               item,
@@ -903,6 +904,10 @@
           collection = getNestedObjectByString(model, collection);
 
           if (!collection) {
+            if (teddy.params.verbosity > 1) {
+              teddy.console.warn('loop element found with undefined value "' + collectionString + '" specified for "through" or "in" attribute. Ignoring element.');
+            }
+
             return '';
           }
           else {


### PR DESCRIPTION
Brought back the warning just as it was with a tweaked verbosity requirement