### PR TITLE
Fixing one line if spacing problem

### DIFF
--- a/teddy.js
+++ b/teddy.js
@@ -978,10 +978,10 @@
         el = removeAttribute(el, 'false');
 
         // Remove all if-conditionals and append condition eval value
-        el = el.replace(midIfBinaryConditionalRegexp, conditionContent ? ' ' + conditionContent : '');
-        el = el.replace(endIfBinaryConditionalRegexp, conditionContent ? ' ' + conditionContent : '');
-        el = el.replace(midIfUnaryConditionalRegexp, conditionContent ? ' ' + conditionContent : '');
-        el = el.replace(endIfUnaryConditionalRegexp, conditionContent ? ' ' + conditionContent : '');
+        el = el.replace(midIfBinaryConditionalRegexp, conditionContent ? ' ' + conditionContent + ' ' : ' ');
+        el = el.replace(endIfBinaryConditionalRegexp, conditionContent ? ' ' + conditionContent + ' ' : ' ');
+        el = el.replace(midIfUnaryConditionalRegexp, conditionContent ? ' ' + conditionContent + ' ' : ' ');
+        el = el.replace(endIfUnaryConditionalRegexp, conditionContent ? ' ' + conditionContent + ' ' : ' ');
 
         // append additional one line content if any
         el += extraString;

--- a/test/conditionals.js
+++ b/test/conditionals.js
@@ -134,8 +134,12 @@ describe('Conditionals', function() {
     done();
   });
 
-  it('should evaluate one line if "if-something=\'Some content\'" as true and still add the id attribute regardless of the if statement outcome (conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html)', function(done) {
-    assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html', model), '<p class=\'something-is-present\' id=\'someId\'>One line if.</p> <p id=\'someId\'>One line if.</p>');
+  it.only('should evaluate one line if "if-something=\'Some content\'" as true and still add the id attribute regardless of the if statement outcome (conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html', model), '<p class=\'something-is-present\' id=\'someId\'>One line if.</p> \
+    <p id=\'someId\'>One line if.</p> \
+    <p disabled id=\'someId\'>One line if.</p> \
+    <option selected value=\'3\'>One line if.</option> \
+    <option value=\'3\' selected >One line if.</option>');
     done();
   });
 

--- a/test/conditionals.js
+++ b/test/conditionals.js
@@ -134,7 +134,7 @@ describe('Conditionals', function() {
     done();
   });
 
-  it.only('should evaluate one line if "if-something=\'Some content\'" as true and still add the id attribute regardless of the if statement outcome (conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html)', function(done) {
+  it('should evaluate one line if "if-something=\'Some content\'" as true and still add the id attribute regardless of the if statement outcome (conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html)', function(done) {
     assert.equalIgnoreSpaces(teddy.render('conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html', model), '<p class=\'something-is-present\' id=\'someId\'>One line if.</p> \
     <p id=\'someId\'>One line if.</p> \
     <p disabled id=\'someId\'>One line if.</p> \

--- a/test/templates/conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html
+++ b/test/templates/conditionals/oneLineValueWithAdditionalAttributesNotImpactedByIf.html
@@ -3,3 +3,6 @@
 !}
 <p if-something='Some content' true="class='something-is-present'" id='someId'>One line if.</p>
 <p if-something='Some content1' true="class='something-is-present'" id='someId'>One line if.</p>
+<p if-something='Some content' true='disabled' id='someId'>One line if.</p>
+<option if-something='Some content' true='selected' value='3'>One line if.</option>
+<option value='3' if-something='Some content' true='selected'>One line if.</option>


### PR DESCRIPTION
Added in proper spacing so occurrences of things like `<option selectedvalue='3'>One line if.</option>` and this `<pid='someId'>One line if.</p>` don't occur.

The unit test will have to be reconsidered because it will give false positive because it doesn't check for spaces which means there is no difference between `<option selectedvalue='3'>One line if.</option>`  and `<option selected value='3'>One line if.</option>` which makes a big difference