### PR TITLE
add test for missing members or objects and arrays

### DIFF
--- a/teddy.js
+++ b/teddy.js
@@ -922,6 +922,9 @@
             }
           }
 
+          // cleanup model when loop finished
+          delete model[val];
+
           return parsedLoop;
         }
       }

--- a/test/looping.js
+++ b/test/looping.js
@@ -145,7 +145,7 @@ describe('Looping', function() {
   });
 
   it('should ignore undefined members of objects and arrays (looping/loopUndefinedMember.html)', function(done) {
-    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p>{letter}</p></p><p>c</p><p>{item.a}</p><p>{item.b}</p><p>{item.c}</p></p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
+    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p>{letter}</p><p>c</p><p>{item.a}</p><p>{item.b}</p><p>{item.c}</p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
     done();
   });
 });

--- a/test/looping.js
+++ b/test/looping.js
@@ -143,4 +143,9 @@ describe('Looping', function() {
     assert.equalIgnoreSpaces(teddy.render('looping/loopInvalidAttributes.html', model), '<div></div>');
     done();
   });
+
+  it('should ignore undefined members of objects and arrays (looping/loopUndefinedMember.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p>c</p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
+    done();
+  });
 });

--- a/test/looping.js
+++ b/test/looping.js
@@ -145,7 +145,7 @@ describe('Looping', function() {
   });
 
   it('should ignore undefined members of objects and arrays (looping/loopUndefinedMember.html)', function(done) {
-    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p>c</p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
+    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p></p></p><p>c</p><p></p><p></p><p></p></p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
     done();
   });
 });

--- a/test/looping.js
+++ b/test/looping.js
@@ -145,7 +145,7 @@ describe('Looping', function() {
   });
 
   it('should ignore undefined members of objects and arrays (looping/loopUndefinedMember.html)', function(done) {
-    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p></p></p><p>c</p><p></p><p></p><p></p></p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
+    assert.equalIgnoreSpaces(teddy.render('looping/loopUndefinedMember.html', model), '<p>a</p><p>{letter}</p></p><p>c</p><p>{item.a}</p><p>{item.b}</p><p>{item.c}</p></p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>');
     done();
   });
 });

--- a/test/misc.js
+++ b/test/misc.js
@@ -180,4 +180,9 @@ describe('Misc', function() {
     assert.equalIgnoreSpaces(teddy.flushCache(5), '');
     done();
   });
+
+  it('should render undefined variables as text (misc/undefinedVar.html)', function(done) {
+    assert.equalIgnoreSpaces(teddy.render('misc/undefinedVar.html', model), '<p>{undefinedVar}</p><p>{definedParent.undefinedMember}</p>');
+    done();
+  });
 });

--- a/test/models/model.js
+++ b/test/models/model.js
@@ -3,8 +3,10 @@ function makeModel() {
         letters: ['a', 'b', 'c'],
         circular: {},
         camelLetters: ['a', 'b', 'c'],
+        missingLetter: ['a', undefined, 'c'],
         names: {jack: 'guy', jill: 'girl', hill: 'landscape'},
         objects: [{a:1, b:2, c:3}, {a:4, b:5, c:6}, {a:7, b:8, c:9}],
+        missingNumbers: [{a:undefined, b:undefined, c:undefined}, {a:4, b:5, c:6}, {a:7, b:8, c:9}],
         objectOfObjects: {one: {a:1, b:2, c:3}, two:{a:4, b:5, c:6}, three:{a:7, b:8, c:9}},
         nestedObjects: [
           {

--- a/test/models/model.js
+++ b/test/models/model.js
@@ -2,6 +2,8 @@ function makeModel() {
   var model = {
         letters: ['a', 'b', 'c'],
         circular: {},
+        undefinedVar: undefined,
+        definedParent: {undefinedMember: undefined},
         camelLetters: ['a', 'b', 'c'],
         missingLetter: ['a', undefined, 'c'],
         names: {jack: 'guy', jill: 'girl', hill: 'landscape'},

--- a/test/templates/looping/loopUndefinedMember.html
+++ b/test/templates/looping/loopUndefinedMember.html
@@ -1,0 +1,12 @@
+{!
+  should ignore undefined members of objects and arrays
+!}
+<loop through='missingLetter' val='letter'>
+  <p>{letter}</p>
+</loop>
+
+<loop through='missingNumbers' val='item'>
+  <p>{item.a}</p>
+  <p>{item.b}</p>
+  <p>{item.c}</p>
+</loop>

--- a/test/templates/misc/undefinedVar.html
+++ b/test/templates/misc/undefinedVar.html
@@ -1,0 +1,6 @@
+{!
+  should render undefined variables as text
+!}
+<p>{undefinedVar}</p>
+
+<p>{definedParent.undefinedMember}</p>


### PR DESCRIPTION
When looping in teddy any undefined member or object property will be evaluated as whatever the last value in the loop was.

In the case of `['a', undefined, 'c']` we'll get `<p>a</p><p>c</p><p>c</p>`